### PR TITLE
Updated the two-tier demo to work with the current version of Terraform

### DIFF
--- a/src/5-gcp-demo/backend/main.tf
+++ b/src/5-gcp-demo/backend/main.tf
@@ -1,10 +1,11 @@
 provider "google" {
-  version = "~> 1.7"
-  project = "cloud-academy-terraform"
+  version = "~> 2.5"
+  project = "terraform-cloudacademy-intro"
   region  = "us-central1"
 }
 
 resource "google_storage_bucket" "backend" {
-  name     = "ca-demo-tf-state"
+  name     = "ca-demo-tf-state-123"
   location = "US"
+  force_destroy = "true"
 }

--- a/src/5-gcp-demo/two-tier/cloudsql.tf
+++ b/src/5-gcp-demo/two-tier/cloudsql.tf
@@ -11,7 +11,7 @@ resource "google_sql_database_instance" "sql_master" {
     disk_autoresize = true
 
     ip_configuration {
-      authorized_networks = {
+      authorized_networks {
         value = "0.0.0.0/0"
       }
 

--- a/src/5-gcp-demo/two-tier/kubernetes.tf
+++ b/src/5-gcp-demo/two-tier/kubernetes.tf
@@ -3,7 +3,7 @@ resource "kubernetes_secret" "mysql" {
     name = "mysql-pass"
   }
 
-  data {
+  data = {
     password = "${var.sql_pass}"
   }
 }
@@ -12,7 +12,7 @@ resource "kubernetes_service" "wordpress" {
   metadata {
     name = "wordpress"
 
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
@@ -23,7 +23,7 @@ resource "kubernetes_service" "wordpress" {
       target_port = 80
     }
 
-    selector {
+    selector = {
       app  = "wordpress"
       tier = "${kubernetes_replication_controller.wordpress.spec.0.selector.tier}"
     }
@@ -36,7 +36,7 @@ resource "kubernetes_persistent_volume_claim" "wordpress" {
   metadata {
     name = "wp-pv-claim"
 
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
@@ -45,7 +45,7 @@ resource "kubernetes_persistent_volume_claim" "wordpress" {
     access_modes = ["ReadWriteOnce"]
 
     resources {
-      requests {
+      requests = {
         storage = "20Gi"
       }
     }
@@ -56,13 +56,13 @@ resource "kubernetes_replication_controller" "wordpress" {
   metadata {
     name = "wordpress"
 
-    labels {
+    labels = {
       app = "wordpress"
     }
   }
 
   spec {
-    selector {
+    selector = {
       app  = "wordpress"
       tier = "frontend"
     }

--- a/src/5-gcp-demo/two-tier/main.tf
+++ b/src/5-gcp-demo/two-tier/main.tf
@@ -1,18 +1,18 @@
 terraform {
   backend "gcs" {
-    bucket = "ca-demo-tf-state"
+    bucket = "ca-demo-tf-state-123"
     prefix = "terraform/state"
   }
 }
 
 provider "google" {
-  version = "~> 1.7"
-  project = "cloud-academy-terraform"
+  version = "~> 2.5"
+  project = "terraform-cloudacademy-intro"
   region  = "${var.region}"
 }
 
 provider "kubernetes" {
-  version = "1.0.1"
+  version = "~> 1.6"
 
   host     = "${google_container_cluster.primary.endpoint}"
   username = "${google_container_cluster.primary.master_auth.0.username}"


### PR DESCRIPTION
Updated the two-tier demo to work with the current version of Terraform (0.12) and supported Google resources.